### PR TITLE
Handle time going backwards, and net consumption never going decreasing

### DIFF
--- a/src/emporia_vue_utility.h
+++ b/src/emporia_vue_utility.h
@@ -565,6 +565,19 @@ class EmporiaVueUtility : public Component,  public UARTDevice {
 
             msg_len = read_msg();
             now = ::time(&now);
+
+            /* sanity checks! */
+            if (next_meter_request >
+                now + (INITIAL_STARTUP_DELAY + METER_REJOIN_INTERVAL)) {
+              ESP_LOGD(TAG,
+                       "Time jumped back (%lld > %lld + %lld); resetting",
+                       (long long) next_meter_request,
+                       (long long) now,
+                       (long long) (INITIAL_STARTUP_DELAY +
+                                    METER_REJOIN_INTERVAL));
+              next_meter_request = next_meter_join = 0;
+            }
+
             if (msg_len != 0) {
 
                 msg_type = input_buffer.data[2];

--- a/src/emporia_vue_utility.h
+++ b/src/emporia_vue_utility.h
@@ -564,7 +564,7 @@ class EmporiaVueUtility : public Component,  public UARTDevice {
             byte inb;
 
             msg_len = read_msg();
-            now = time(&now);
+            now = ::time(&now);
             if (msg_len != 0) {
 
                 msg_type = input_buffer.data[2];

--- a/src/emporia_vue_utility.h
+++ b/src/emporia_vue_utility.h
@@ -47,7 +47,9 @@ class EmporiaVueUtility : public Component,  public UARTDevice {
         Sensor *kWh_net      = new Sensor();
         Sensor *kWh_consumed = new Sensor();
         Sensor *kWh_returned = new Sensor();
-        Sensor *W       = new Sensor();
+        Sensor *W            = new Sensor();
+        Sensor *W_consumed   = new Sensor();
+        Sensor *W_returned   = new Sensor();
 
         const char *TAG = "Vue";
 
@@ -428,6 +430,13 @@ class EmporiaVueUtility : public Component,  public UARTDevice {
                 last_reading_has_error = 1;
             } else {
                 W->publish_state(watts);
+                if (watts > 0) {
+                  W_consumed->publish_state(watts);
+                  W_returned->publish_state(0);
+                } else {
+                  W_consumed->publish_state(0);
+                  W_returned->publish_state(-watts);
+                }
             }
             return(watts);
         }

--- a/src/vue-utility-solar.yaml
+++ b/src/vue-utility-solar.yaml
@@ -42,7 +42,7 @@ sensor:
       lambda: |-
         auto vue = new EmporiaVueUtility(id(emporia_uart));
         App.register_component(vue);
-        return {vue->kWh_consumed, vue->kWh_returned, vue->W, vue->kWh_net};
+        return {vue->kWh_consumed, vue->kWh_returned, vue->W_consumed, vue->W_returned, vue->W, vue->kWh_net};
       sensors:
           - name: "kWh Consumed"
             id: kWh_consumed
@@ -87,6 +87,44 @@ sensor:
                 then:
                     lambda: |-
                         ESP_LOGI("Vue", "kWh = %0.3f", x);
+
+          - name: "Watts consumed"
+            id: watts_consumed
+            unit_of_measurement: "W"
+            accuracy_decimals: 0
+            state_class: measurement
+            device_class: power
+            # Report every 5 minutes or when +/- 20 watts
+            filters:
+                - or:
+                    - throttle: 5min
+                    - delta: 20  # <- watts
+                    - lambda: |-
+                        if (id(fast_reporting)) return(x);
+                        return {};
+            on_raw_value:
+                then:
+                    lambda: |-
+                        ESP_LOGI("Vue", "Watts consumed = %0.3f", x);
+
+          - name: "Watts returned"
+            id: watts_returned
+            unit_of_measurement: "W"
+            accuracy_decimals: 0
+            state_class: measurement
+            device_class: power
+            # Report every 5 minutes or when +/- 20 watts
+            filters:
+                - or:
+                    - throttle: 5min
+                    - delta: 20  # <- watts
+                    - lambda: |-
+                        if (id(fast_reporting)) return(x);
+                        return {};
+            on_raw_value:
+                then:
+                    lambda: |-
+                        ESP_LOGI("Vue", "Watts returned = %0.3f", x);
 
           - name: "Watts"
             id: watts


### PR DESCRIPTION
On my meter, kWh net never decreases. However, Watts _does_ go negative. This PR adds sensors that can be integrated in Home Assistant to make net metering make sense.
Furthermore, if using e.g. https://esphome.io/components/time/homeassistant.html, time _can_ jump backwards, which breaks communication with the meter. This PR adds sanity checks to

1. allow usage of time components without breaking compilation, and
2. handling backwards time jumps by resetting the `next_` variable(s)
