### PR TITLE
Fix MQTT id attribute

### DIFF
--- a/src/vue-utility-solar.yaml
+++ b/src/vue-utility-solar.yaml
@@ -25,7 +25,7 @@ api:
 
 mqtt:
     broker: !secret mqtt_broker
-    id: vue-utility
+    id: vue_utility
     username: !secret mqtt_username
     password: !secret mqtt_password
     discovery: False # Only if you use the HA API usually

--- a/src/vue-utility.yaml
+++ b/src/vue-utility.yaml
@@ -25,7 +25,7 @@ api:
 
 mqtt:
     broker: !secret mqtt_broker
-    id: vue-utility
+    id: vue_utility
     username: !secret mqtt_username
     password: !secret mqtt_password
     discovery: False # Only if you use the HA API usually


### PR DESCRIPTION
In newer versions of esphome, the `id` attribute of `mqtt` doesn't accept dash '-'. Replace it with underscore '_'.